### PR TITLE
Enable the passing of options for SPI devices with defaults

### DIFF
--- a/mcp3008.js
+++ b/mcp3008.js
@@ -36,9 +36,14 @@ function stopInstance (instance) {
     }
 }
 
-var Mcp3008 = function (dev) {
+var Mcp3008 = function (dev, options) {
     device = dev || device;
-    spi = new SPI.Spi(device, [], function (s) {
+    options = options || {
+        mode: 0,        // Mode 0
+        chipSelect: 0,  // Low
+        maxSpeed: 15000 // 15khz is a good speed for the mcp3008
+    };
+    spi = new SPI.Spi(device, options, function (s) {
         s.open();
     });
 


### PR DESCRIPTION
Adding an options argument to the constructor that is passed into the
SPI constructor.  This allows the end-user to set things like mode,
chipSelect, etc.

Include defaults for the options that are shown to work on the raspberry
pi (see RussTheAerialist/node-spi#17 for background).  15khz was chosen
because it's close to the optimal speed for the mcp3008 according to the
datasheet.
