### PR TITLE
stopInstance is not defined

### DIFF
--- a/mcp3008.js
+++ b/mcp3008.js
@@ -28,7 +28,7 @@ function read(channel, callback) {
 }
 
 function stopInstance (instance) {
-    if (instance != undefined) {
+    if (instance !== undefined) {
         clearInterval(instance.poller);
     }
 }

--- a/mcp3008.js
+++ b/mcp3008.js
@@ -27,6 +27,12 @@ function read(channel, callback) {
     });
 }
 
+function stopInstance (instance) {
+    if (instance != undefined) {
+        clearInterval(instance.poller);
+    }
+}
+
 function startPoll (channel, callback) {
     isLegalChannel(channel);
     channels[channel].poller = setInterval(function () {


### PR DESCRIPTION
when calling stop or close, stopInstance is not defined would show up. It seems it was overzealously removed during spi to pi-spi change. 